### PR TITLE
Does this fix a memory leak?

### DIFF
--- a/ch08-inheritance-and-polymorphism/ExtremeC_examples_chapter8_2_person.c
+++ b/ch08-inheritance-and-polymorphism/ExtremeC_examples_chapter8_2_person.c
@@ -24,7 +24,7 @@ void person_ctor(person_t* person,
 
 // Destructor
 void person_dtor(person_t* person) {
-  // Nothing to do
+  free(person);
 }
 
 // Behavior functions

--- a/ch08-inheritance-and-polymorphism/ExtremeC_examples_chapter8_3_person.c
+++ b/ch08-inheritance-and-polymorphism/ExtremeC_examples_chapter8_3_person.c
@@ -28,7 +28,7 @@ void person_ctor(person_t* person,
 
 // Destructor
 void person_dtor(person_t* person) {
-  // Nothing to do
+  free(person);
 }
 
 // Behavior functions

--- a/ch08-inheritance-and-polymorphism/ExtremeC_examples_chapter8_3_person.c
+++ b/ch08-inheritance-and-polymorphism/ExtremeC_examples_chapter8_3_person.c
@@ -28,7 +28,7 @@ void person_ctor(person_t* person,
 
 // Destructor
 void person_dtor(person_t* person) {
-  free(person);
+  // Nothing to do
 }
 
 // Behavior functions


### PR DESCRIPTION
It looks like there could be a memory leak in this example. person_dtor() is not freeing the passed in pointer, therefore when student_dtor() calls the base class' destructor the allocated memory is never released.

If I've missed where there memory is freed I would love to know.