### PR TITLE
Fix Makefile build examples

### DIFF
--- a/ch23-build-systems/ex23_1/Makefile
+++ b/ch23-build-systems/ex23_1/Makefile
@@ -10,7 +10,7 @@ LIBCALC = ${BUILD_DIR}/lib${LIBCALCNAME}.a
 EXEC = ${BUILD_DIR}/ex23_1.out
 
 build: prereq ${BUILD_DIR}/exec/main.o ${LIBCALC}
-	${CC} -L${BUILD_DIR} -l${LIBCALCNAME} ${BUILD_DIR}/exec/main.o -o ${EXEC}
+	${CC} -L${BUILD_DIR} -l${LIBCALCNAME} -o ${EXEC}
 
 prereq:
 	mkdir -p ${BUILD_DIR}

--- a/ch23-build-systems/ex23_1/Makefile-by-pattern
+++ b/ch23-build-systems/ex23_1/Makefile-by-pattern
@@ -10,7 +10,7 @@ LIBCALC = ${BUILD_DIR}/lib${LIBCALCNAME}.a
 EXEC = ${BUILD_DIR}/ex23_1.out
 
 build: prereq ${BUILD_DIR}/exec/main.o ${LIBCALC}
-	${CC} -L${BUILD_DIR} -l${LIBCALCNAME} ${BUILD_DIR}/exec/main.o -o ${EXEC}
+	${CC} -L${BUILD_DIR} -l${LIBCALCNAME} -o ${EXEC}
 
 prereq:
 	mkdir -p ${BUILD_DIR}

--- a/ch23-build-systems/ex23_1/Makefile-simple
+++ b/ch23-build-systems/ex23_1/Makefile-simple
@@ -1,13 +1,13 @@
 CC = gcc
 
 build: prereq out/main.o out/libcalc.a
-	${CC} -Lout -lcalc out/main.o -o out/ex23_1.out
+	${CC} -Lout -lcalc -o out/ex23_1.out
 
 prereq:
 	mkdir -p out
 
 out/libcalc.a: out/add.o out/multiply.o out/subtract.o
-	ar rcs out/libcalc.a out/add.o out/multiply.o out/subtract.o
+	ar rcs out/libcalc.a out/add.o out/multiply.o out/subtract.o out/main.o
 
 out/main.o: exec/main.c calc/calc.h
 	${CC} -c -Icalc exec/main.c -o out/main.o

--- a/ch23-build-systems/ex23_1/Makefile-very-simple
+++ b/ch23-build-systems/ex23_1/Makefile-very-simple
@@ -5,6 +5,6 @@ build:
 	gcc -c calc/add.c -o out/add.o
 	gcc -c calc/multiply.c -o out/multiply.o
 	gcc -c calc/subtract.c -o out/subtract.o
-	ar rcs out/libcalc.a out/add.o out/multiply.o out/subtract.o
 	gcc -c -Icalc exec/main.c -o out/main.o
-	gcc -Lout -lcalc out/main.o -o out/ex23_1.out
+	ar rcs out/libcalc.a out/add.o out/multiply.o out/subtract.o out/main.o
+	gcc -Lout -lcalc  -o out/ex23_1.out


### PR DESCRIPTION
In this pull request you can find fixes for classes not found exception

It resolves this kind of errors in running make

main.c:(.text+0x1a): undefined reference to `add'
/usr/bin/ld: main.c:(.text+0x3f): undefined reference to `subtract'
/usr/bin/ld: main.c:(.text+0x64): undefined reference to `multiply'

tested on gcc version 12.2.0 (Debian 12.2.0-14) 